### PR TITLE
Switch to regex sub from python replace so that other file extensions…

### DIFF
--- a/piece/piecedesign.py
+++ b/piece/piecedesign.py
@@ -21,12 +21,13 @@ import subprocess, platform
 class piecedesign() :
     def __init__(self, pbase, todo_path, filepath, design_opt) -> None:
         import re
+        import os
         self._todo_path = todo_path
         self.__design_opt = design_opt
         self.__platform = platform.system()
 
         self.filepath = filepath
-        self.tmpfile_path = re.sub(r"\.fasta|\.afa|\.fa", ".mc.fasta", self.filepath) if self.filepath is not None and '.fasta' in self.filepath else pbase.errorlog('文件路径为空，或命名错误')
+        self.tmpfile_path = re.sub(r"\.fasta|\.afa|\.fa", ".mc.fasta", self.filepath) if self.filepath is not None and os.path.splitext(self.filepath)[1] in [ '.fasta', '.afa', '.fa'] else pbase.errorlog('文件路径为空，或命名错误')
         self._base = pbase
 
     '''

--- a/piece/piecedesign.py
+++ b/piece/piecedesign.py
@@ -20,13 +20,13 @@ import subprocess, platform
 #多序列比对、保守区间遍历、PCR设计等
 class piecedesign() :
     def __init__(self, pbase, todo_path, filepath, design_opt) -> None:
+        import re
         self._todo_path = todo_path
         self.__design_opt = design_opt
         self.__platform = platform.system()
 
         self.filepath = filepath
-        self.tmpfile_path = self.filepath.replace('.fasta', '.mc.fasta') if self.filepath is not None and '.fasta' in self.filepath else pbase.errorlog('文件路径为空，或命名错误')
-
+        self.tmpfile_path = re.sub(r"\.fasta|\.afa|\.fa", ".mc.fasta", self.filepath) if self.filepath is not None and '.fasta' in self.filepath else pbase.errorlog('文件路径为空，或命名错误')
         self._base = pbase
 
     '''


### PR DESCRIPTION
## Pull Request: Implement Enhanced File Extension Handling

### Proposed Changes

This pull request addresses the issue [#5 ]: **Enhanced File Extension Handling**, where we proposed to improve the system's file extension handling by replacing the fixed string-based replacement with a more versatile regex-based approach.

The current code snippet in the `piecedesign` class processes input files with a fixed extension of `.fasta`:

```python
self.tmpfile_path = self.filepath.replace('.fasta', '.mc.fasta') if self.filepath is not None and '.fasta' in self.filepath else pbase.errorlog('文件路径为空，或命名错误')
```
To enhance flexibility and accommodate multiple file extensions, including .fasta, .afa, and .fa, we have made the following change:
```python
import re
self.tmpfile_path = re.sub(r"\.fasta|\.afa|\.fa", ".mc.fasta", self.filepath) if self.filepath is not None and '.fasta' in self.filepath else pbase.errorlog('文件路径为空，或命名错误')
```


